### PR TITLE
Sync tags from Pocket to Pinboard

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ export const handler = async () => {
       authToken: `${pinboardToken}`,
       url: pb.givenUrl,
       description: pb.resolvedTitle,
+      tags: pb.tags,
     });
   });
 

--- a/src/pocketApi.ts
+++ b/src/pocketApi.ts
@@ -19,12 +19,18 @@ type ArchiveRequestProps = AuthProps & {
   itemIds: ItemId[];
 };
 
+type PocketTag = {
+  itemId: string;
+  tag: string;
+};
+
 type PocketItem = {
-  itemId: "string";
-  resolvedId: "string";
-  givenUrl: "string";
-  givenTitle: "string";
-  resolvedTitle: "string";
+  itemId: string;
+  resolvedId: string;
+  givenUrl: string;
+  givenTitle: string;
+  resolvedTitle: string;
+  tags: string[];
 };
 
 type GetResponseItem = {
@@ -33,6 +39,7 @@ type GetResponseItem = {
   given_url: string;
   given_title: string;
   resolved_title: string;
+  tags: Record<string, PocketTag>;
 };
 
 type GetBookmarksResponse = {
@@ -85,6 +92,7 @@ export async function getBookmarks({
         givenUrl: responseItem.given_url,
         givenTitle: responseItem.given_title,
         resolvedTitle: responseItem.resolved_title,
+        tags: Object.keys(responseItem.tags),
       } as PocketItem)
   );
 }


### PR DESCRIPTION
A tag in Pinboard is "up to 255 characters. May not contain commas or whitespace." (https://pinboard.in/api/#entity_tag). 

The response shape of tags from Pocket looks like:

```
{
  developer: { item_id: 'xxx', tag: 'developer' },
  pocket: { item_id: 'xxx', tag: 'pocket' },
  tag: { item_id: 'xxx', tag: 'tag' }
}
```

I am taking the key of each tag. In the future, it might make sense to tag the `tag` property of each tag, and sanitise it to Pinboard's requirements.