### PR TITLE
Make description values optional and find value before sending to Pinboard

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { getConfigItem } from "./config";
+import { getDescription } from "./lib";
 import * as pocketApi from "./pocketApi";
 import * as pinboardApi from "./pinboardApi";
 
@@ -23,13 +24,13 @@ export const handler = async () => {
   const pinboardToken = await getConfigItem("pinboardToken");
   await Promise.all(
     pocketBookmarks.map(async (pb) => {
+      const description = getDescription(pb);
       const bookmarkToSave = {
         authToken: `${pinboardToken}`,
         url: pb.givenUrl,
-        description: pb.resolvedTitle,
+        description,
         tags: pb.tags,
       };
-      console.log(bookmarkToSave);
       await pinboardApi.saveBookmark(bookmarkToSave);
     })
   );

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,0 +1,44 @@
+import { getDescription, isEmptyString } from "./lib";
+import { PocketItem } from "./pocketApi";
+
+test("isEmptyString should be false if input is not an empty string", () => {
+  expect(isEmptyString("123")).toBeFalsy();
+  expect(isEmptyString("abc")).toBeFalsy();
+  expect(isEmptyString("ABC123&^^%")).toBeFalsy();
+});
+
+test("isEmptyString should return true if string is empty", () => {
+  expect(isEmptyString("")).toBeTruthy();
+  expect(isEmptyString()).toBeTruthy();
+});
+
+test("getDescription should return the correct value", () => {
+  const pocketBookmarkNoTitle = {
+    givenUrl: "test.com",
+    itemId: "1",
+    resolvedId: "1",
+    tags: [],
+  } as PocketItem;
+  const resultA = getDescription(pocketBookmarkNoTitle);
+  expect(resultA).toBe("test.com");
+
+  const pocketBookmarkNoResolvedTitle = {
+    givenUrl: "test.com",
+    itemId: "1",
+    resolvedId: "1",
+    tags: [],
+    givenTitle: "givenTitle",
+  } as PocketItem;
+  const resultB = getDescription(pocketBookmarkNoResolvedTitle);
+  expect(resultB).toBe("givenTitle");
+
+  const pocketBookmarkWithResolvedTitle = {
+    givenUrl: "test.com",
+    itemId: "1",
+    resolvedId: "1",
+    tags: [],
+    resolvedTitle: "resolvedTitle",
+  } as PocketItem;
+  const resultC = getDescription(pocketBookmarkWithResolvedTitle);
+  expect(resultC).toBe("resolvedTitle");
+});

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,10 @@
+import type { PocketItem } from "./pocketApi";
+
+export const isEmptyString = (str: string | undefined = ""): boolean =>
+  str.length == 0;
+
+export const getDescription = (pocketBookmark: PocketItem): string => {
+  if (pocketBookmark.resolvedTitle) return pocketBookmark.resolvedTitle;
+  else if (pocketBookmark.givenTitle) return pocketBookmark.givenTitle;
+  else return pocketBookmark.givenUrl;
+};

--- a/src/pinboardApi.ts
+++ b/src/pinboardApi.ts
@@ -41,10 +41,12 @@ export const saveBookmark = async ({
   const apiUrl = new URL(`${apiBase}/posts/add`);
   apiUrl.searchParams.append("auth_token", authToken);
   apiUrl.searchParams.append("url", url);
-  apiUrl.searchParams.append("description", description);
   apiUrl.searchParams.append("shared", shared ? "yes" : "no");
   apiUrl.searchParams.append("replace", replace ? "yes" : "no");
   apiUrl.searchParams.append("format", "json");
+  if (description) {
+    apiUrl.searchParams.append("description", description);
+  }
   if (tags.length) {
     apiUrl.searchParams.append("tags", tags.join(","));
   }

--- a/src/pocketApi.ts
+++ b/src/pocketApi.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { isEmptyString } from "./lib";
 
 const apiBase = "https://getpocket.com/v3";
 
@@ -24,12 +25,12 @@ type PocketTag = {
   tag: string;
 };
 
-type PocketItem = {
+export type PocketItem = {
   itemId: string;
   resolvedId: string;
   givenUrl: string;
-  givenTitle: string;
-  resolvedTitle: string;
+  givenTitle?: string;
+  resolvedTitle?: string;
   tags: string[];
 };
 
@@ -90,8 +91,12 @@ export async function getBookmarks({
         itemId: responseItem.item_id,
         resolvedId: responseItem.resolved_id,
         givenUrl: responseItem.given_url,
-        givenTitle: responseItem.given_title,
-        resolvedTitle: responseItem.resolved_title,
+        givenTitle: !isEmptyString(responseItem.given_title)
+          ? responseItem.given_title
+          : undefined,
+        resolvedTitle: !isEmptyString(responseItem.resolved_title)
+          ? responseItem.resolved_title
+          : undefined,
         tags: Object.keys(responseItem.tags ?? {}),
       } as PocketItem)
   );


### PR DESCRIPTION
* Refactor to allow missing `resolvedTitle` or `givenTitle`
* If there is no title, the `description` for Pinboard should be the URL of the item, as `description` is a required field in the Pinboard API