### PR TITLE
Ignore node-fetch major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "node-fetch"
+        update-types: ["version-update:semver-major"]
     assignees:
       - "georgeblahblah"


### PR DESCRIPTION
## What does this change?

- Asks dependabot to ignore major versions of `node-fetch`. `node-fetch@3` is ESM only