### PR TITLE
Add build to test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,5 @@ jobs:
           node-version-file: '.nvmrc'
       - run: |
           yarn install
+          yarn build
           yarn test


### PR DESCRIPTION
## Why?

- So the pipeline fails if a change means the project doesn't compile